### PR TITLE
add support for farms

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -124,7 +124,7 @@ class syntax_plugin_inclform extends DokuWiki_Syntax_Plugin {
 	}
         if(file_exists(DOKU_INC . $path)) {
 	    //echo "<!-- form was found -->\n";
-	    $text = io_readFile($path); 
+	    $text = io_readFile(DOKU_INC . $path); 
 	    $pattern = "/(<\?php)(.*?)(\?>)/is";			
 	    $text = eval_form_php($text);
 	} else {


### PR DESCRIPTION
This fixes an outstanding bug preventing compatibility with dokuwiki farms. It reads the included .php file using the absolute path rather than the relative path.

Forms must be stored in your installation's *farmer* directory, not the animals, e.g. `/usr/share/webapps/dokuwiki/core/data/forms`.